### PR TITLE
Fixing the PTB data set 404 issue

### DIFF
--- a/getdata.sh
+++ b/getdata.sh
@@ -6,9 +6,13 @@ cd data
 echo "- Downloading Penn Treebank (PTB)"
 mkdir -p penn
 cd penn
-wget --quiet --continue https://github.com/pytorch/examples/raw/master/word_language_model/data/penn/train.txt
-wget --quiet --continue https://github.com/pytorch/examples/raw/master/word_language_model/data/penn/valid.txt
-wget --quiet --continue https://github.com/pytorch/examples/raw/master/word_language_model/data/penn/test.txt
+wget --quiet --continue http://www.fit.vutbr.cz/~imikolov/rnnlm/simple-examples.tgz
+tar -xzf simple-examples.tgz
+mv simple-examples/data/ptb.train.txt train.txt
+mv simple-examples/data/ptb.test.txt test.txt
+mv simple-examples/data/ptb.valid.txt valid.txt
+rm -rf simple-examples.tgz
+rm -rf simple-examples/
 cd ..
 
 echo "- Downloading WikiText-2 (WT2)"


### PR DESCRIPTION
PyTorch had to remove the PTB data set from their repo which broke our `getdata.sh` script. I'm now downloading it directly from Mikolov's website, and doing some book-keeping on top.