### PR TITLE
Fix setting model dropoutE when resume and remove lr overwrite

### DIFF
--- a/main.py
+++ b/main.py
@@ -119,8 +119,7 @@ model = model.RNNModel(args.model, ntokens, args.emsize, args.nhid, args.nlayers
 if args.resume:
     print('Resuming model ...')
     model_load(args.resume)
-    optimizer.param_groups[0]['lr'] = args.lr
-    model.dropouti, model.dropouth, model.dropout, args.dropoute = args.dropouti, args.dropouth, args.dropout, args.dropoute
+    model.dropouti, model.dropouth, model.dropout, model.dropoute = args.dropouti, args.dropouth, args.dropout, args.dropoute
     if args.wdrop:
         from weight_drop import WeightDrop
         for rnn in model.rnns:


### PR DESCRIPTION
1. Fix setting of model.dropoute to the value from cli arguments.
2. Remove overwriting lr to initial value in resume because it leads to model divergence when training has been resumed after few decreases of lr (scheduled by args.when parameter)