### PR TITLE
Uses "--no-cuda" and implements device-agnostic code

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -12,6 +12,8 @@ from torch.autograd import Variable
 
 import data
 
+from utils import init_device
+
 parser = argparse.ArgumentParser(description='PyTorch PTB Language Model')
 
 # Model parameters.
@@ -27,8 +29,8 @@ parser.add_argument('--words', type=int, default='1000',
                     help='number of words to generate')
 parser.add_argument('--seed', type=int, default=1111,
                     help='random seed')
-parser.add_argument('--cuda', action='store_true',
-                    help='use CUDA')
+parser.add_argument('--no-cuda', action='store_true',
+                    help='do not use CUDA')
 parser.add_argument('--temperature', type=float, default=1.0,
                     help='temperature - higher will increase diversity')
 parser.add_argument('--log-interval', type=int, default=100,
@@ -37,32 +39,23 @@ args = parser.parse_args()
 
 # Set the random seed manually for reproducibility.
 torch.manual_seed(args.seed)
-if torch.cuda.is_available():
-    if not args.cuda:
-        print("WARNING: You have a CUDA device, so you should probably run with --cuda")
-    else:
-        torch.cuda.manual_seed(args.seed)
+# Sets the `args.device` and CUDA seed.
+init_device(args)
 
 if args.temperature < 1e-3:
     parser.error("--temperature has to be greater or equal 1e-3")
 
 with open(args.checkpoint, 'rb') as f:
-    model = torch.load(f)
+    model = torch.load(f, map_location=args.device)
 model.eval()
 if args.model == 'QRNN':
     model.reset()
-
-if args.cuda:
-    model.cuda()
-else:
-    model.cpu()
 
 corpus = data.Corpus(args.data)
 ntokens = len(corpus.dictionary)
 hidden = model.init_hidden(1)
 input = Variable(torch.rand(1, 1).mul(ntokens).long(), volatile=True)
-if args.cuda:
-    input.data = input.data.cuda()
+input.data = input.data.to(args.device)
 
 with open(args.outf, 'w') as outf:
     for i in range(args.words):

--- a/pointer.py
+++ b/pointer.py
@@ -9,7 +9,7 @@ from torch.autograd import Variable
 import data
 import model
 
-from utils import batchify, get_batch, repackage_hidden
+from utils import batchify, get_batch, repackage_hidden, init_device
 
 parser = argparse.ArgumentParser(description='PyTorch PennTreeBank RNN/LSTM Language Model')
 parser.add_argument('--data', type=str, default='data/penn',
@@ -18,8 +18,8 @@ parser.add_argument('--model', type=str, default='LSTM',
                     help='type of recurrent net (LSTM, QRNN)')
 parser.add_argument('--save', type=str,default='best.pt',
                     help='model to use the pointer over')
-parser.add_argument('--cuda', action='store_false',
-                    help='use CUDA')
+parser.add_argument('--no-cuda', action='store_true',
+                    help='do not use CUDA')
 parser.add_argument('--bptt', type=int, default=5000,
                     help='sequence length')
 parser.add_argument('--window', type=int, default=3785,
@@ -29,6 +29,9 @@ parser.add_argument('--theta', type=float, default=0.6625523432485668,
 parser.add_argument('--lambdasm', type=float, default=0.12785920428335693,
                     help='linear mix between only pointer (1) and only vocab (0) distribution')
 args = parser.parse_args()
+
+# Choose between CUDA or CPU and sets `args.device`
+init_device(args)
 
 ###############################################################################
 # Load data
@@ -49,12 +52,10 @@ test_data = batchify(corpus.test, test_batch_size, args)
 ntokens = len(corpus.dictionary)
 criterion = nn.CrossEntropyLoss()
 
-def one_hot(idx, size, cuda=True):
+def one_hot(idx, size):
     a = np.zeros((1, size), np.float32)
     a[0][idx] = 1
-    v = Variable(torch.from_numpy(a))
-    if cuda: v = v.cuda()
-    return v
+    return Variable(torch.from_numpy(a)).to(args.device)
 
 def evaluate(data_source, batch_size=10, window=args.window):
     # Turn on evaluation mode which disables dropout.
@@ -114,10 +115,7 @@ def evaluate(data_source, batch_size=10, window=args.window):
 
 # Load the best saved model.
 with open(args.save, 'rb') as f:
-    if not args.cuda:
-        model = torch.load(f, map_location=lambda storage, loc: storage)
-    else:
-        model = torch.load(f)
+    model = torch.load(f, map_location=args.device)
 print(model)
 
 # Run on val data.

--- a/utils.py
+++ b/utils.py
@@ -27,3 +27,23 @@ def get_batch(source, i, args, seq_len=None, evaluation=False):
     data = source[i:i+seq_len]
     target = source[i+1:i+1+seq_len].view(-1)
     return data, target
+
+
+def init_device(args):
+    """Sets the `args.device` attribute based on `args.no_cuda` and host
+    availability. It also sets the CUDA seed if needed.
+    """
+    if torch.cuda.is_available():
+        if args.no_cuda:
+            print('WARNING: You have a CUDA device,'
+                  'so you should probably not run with --no_cuda')
+            setattr(args, 'device', torch.device('cpu'))
+        else:
+            if hasattr(args, 'seed'):
+                torch.cuda.manual_seed(args.seed)
+            setattr(args, 'device', torch.device('cuda'))
+    else:
+        if not args.no_cuda:
+            print('WARNING: No CUDA device found, using CPU. '
+                  'It would be best to explicitly run with --no_cuda')
+        setattr(args, 'device', torch.device('cpu'))

--- a/utils.py
+++ b/utils.py
@@ -16,9 +16,7 @@ def batchify(data, bsz, args):
     # Trim off any extra elements that wouldn't cleanly fit (remainders).
     data = data.narrow(0, 0, nbatch * bsz)
     # Evenly divide the data across the bsz batches.
-    data = data.view(bsz, -1).t().contiguous()
-    if args.cuda:
-        data = data.cuda()
+    data = data.view(bsz, -1).t().contiguous().to(args.device)
     return data
 
 


### PR DESCRIPTION
This pull request adds two contributions:

1. Changes the input arguments `--cuda` to `--no-cuda`, with consistent behavior
2. Follows Pytorch [best practice](https://pytorch.org/docs/stable/notes/cuda.html#best-practices) for device agnostic code, which makes the code cleaner and executions compatible between CPU and GPU runs (loading on a CPU a model trained on a GPU and vice-versa).

In summary, I added a new utility function `init_device()` in `utils.py`, which adds to `args` a `device` property. This property is a [`torch.device()`](https://pytorch.org/docs/stable/tensor_attributes.html#torch-device) object which indicates where tensors and models should reside. We can then write code without knowing if the computation is on the CPU or GPU. For example with a tensor: `data = torch.rand(10, device=args.device)` or a model: `model = model.to(args.device)`. This completely removes the need to write conditional blocks.

If using the "--no-cuda" (or there is no CUDA device available), the device is set to the CPU.

This version was checked against the [Experiments](https://github.com/salesforce/awd-lstm-lm#experiments) with consistent results.
Related to #23 and #6 