### PR TITLE
Fix cuda flag.

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,7 +45,7 @@ parser.add_argument('--seed', type=int, default=1111,
                     help='random seed')
 parser.add_argument('--nonmono', type=int, default=5,
                     help='random seed')
-parser.add_argument('--cuda', action='store_false',
+parser.add_argument('--cuda', action='store_true', default=False,
                     help='use CUDA')
 parser.add_argument('--log-interval', type=int, default=200, metavar='N',
                     help='report interval')


### PR DESCRIPTION
This resolves issue [this issue](https://github.com/salesforce/awd-lstm-lm/issues/80) whereby people without GPUs can't run the examples, and whereby regardless of GPUs being present, the flag --cuda does the opposite of what it should be doing.